### PR TITLE
Minor updates on the KFServing installation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In the repository describe with 3 files :
 ``` chmod +x *.sh ```
  
 ## Create new GKE cluster with kubeflow pipelines
-```./kfserving-install.sh ```
+```./k8s-kubeflow-install.sh ```
  
 ## Use an existing GKE cluster with installed Kubeflow pipelines
 
@@ -31,7 +31,7 @@ In order to use an existing cluster the `kubectl` CLI should be properly authent
 `gcloud container clusters get-credentials <your cluster's name>`
 
 ## Install KFserving and sklearn test
-``` ./k8s-kubeflow-install.sh ```
+``` ./kfserving-install.sh ```
  
 ## Uninstall kubeflow pipelines and delete GKE cluster
 ``` ./uninstall.sh ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ In the repository describe with 3 files :
 ## Create new GKE cluster with kubeflow pipelines
 ```./kfserving-install.sh ```
  
+## Use an existing GKE cluster with installed Kubeflow pipelines
+
+In order to use an existing cluster the `kubectl` CLI should be properly authenticated. This can be done with the `gcloud` CLI tool as follows:
+
+`gcloud container clusters get-credentials <your cluster's name>`
+
 ## Install KFserving and sklearn test
 ``` ./k8s-kubeflow-install.sh ```
  

--- a/kfserving-install.sh
+++ b/kfserving-install.sh
@@ -73,8 +73,14 @@ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/relea
 kubectl wait --for=condition=available --timeout=600s deployment/cert-manager-webhook -n cert-manager
 cd ..
 # Install KFServing
-git clone https://github.com/kubeflow/kfserving.git
-cd kfserving
+if [[ -d kfserving ]]; then
+  cd kfserving
+  git pull
+else
+  git clone https://github.com/kubeflow/kfserving.git
+  cd kfserving
+fi
+
 K8S_MINOR=$(kubectl version | perl -ne 'print $1."\n" if /Server Version:.*?Minor:"(\d+)"/')
 if [[ $K8S_MINOR -gt 17 ]]; then
   echo "Kubernetes minor version must be <= 17 got ${K8S_MINOR}"
@@ -90,18 +96,31 @@ echo "Check KFServing controller installation"
 sleep 30
 kubectl get po -n kfserving-system 
 echo "========== Create KFServing test inference service =========="
-kubectl create namespace kfserving-test
-kubectl apply -f docs/samples/sklearn/sklearn.yaml -n kfserving-test
+kubectl get namespace kfserving-test || kubectl create namespace kfserving-test
+kubectl apply -f docs/samples/v1alpha2/sklearn/sklearn.yaml -n kfserving-test
 sleep 60
-echo "========== Check KFServing InferenceService status =========="
-kubectl get inferenceservices sklearn-iris -n kfserving-test
+
+n=0
+until [ "$n" -ge 5 ]
+do
+  echo "========== Check KFServing InferenceService status =========="
+  STATUS=`kubectl get inferenceservices sklearn-iris -n kfserving-test`
+  echo "$STATUS"
+  if [[ $STATUS == *"http:"* ]]; then
+    break
+  fi
+  n=$((n+1))
+  echo "Servce does not seem to be ready, retrying after 60 seconds..."
+  sleep 60
+done
+
 sleep 10
 export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
 sleep 5
 echo "========== Curl the InferenceService from ingress gateway =========="
 SERVICE_HOSTNAME=$(kubectl get inferenceservice sklearn-iris -n kfserving-test -o jsonpath='{.status.url}' | cut -d "/" -f 3)
-curl -v -H "Host: ${SERVICE_HOSTNAME}" http://${INGRESS_HOST}:${INGRESS_PORT}/v1/models/sklearn-iris:predict -d @./docs/samples/sklearn/iris-input.json
+curl -v -H "Host: ${SERVICE_HOSTNAME}" http://${INGRESS_HOST}:${INGRESS_PORT}/v1/models/sklearn-iris:predict -d @./docs/samples/v1alpha2/sklearn/iris-input.json
 
 # Clean up
 rm -rf istio-${ISTIO_VERSION}


### PR DESCRIPTION
1. Readme updated with a section that describes how to use an existing GKE cluster
2. Minor modifications in `kfserving-install.sh` script in order to make it possible to re-run the script on failures
3. update the path references in the sklearn sample deployment commands (there was a refactor in the kfserving repo)
